### PR TITLE
AggregagtedData renamed AggregatedPrefs

### DIFF
--- a/src/main/java/io/github/oliviercailloux/teach_spreadsheets/base/AggregatedPrefs.java
+++ b/src/main/java/io/github/oliviercailloux/teach_spreadsheets/base/AggregatedPrefs.java
@@ -16,11 +16,11 @@ import static com.google.common.base.Preconditions.checkArgument;
  * several input vows files.
  *
  */
-public class AggregatedData {
+public class AggregatedPrefs {
 	private ImmutableSet<TeacherPrefs> TeacherPrefsSet;
 	private ImmutableSet<Course> courses;
 
-	private AggregatedData(Set<TeacherPrefs> teacherPrefsSet, Set<Course> courses) {
+	private AggregatedPrefs(Set<TeacherPrefs> teacherPrefsSet, Set<Course> courses) {
 		this.TeacherPrefsSet = ImmutableSet.copyOf(teacherPrefsSet);
 		this.courses = ImmutableSet.copyOf(courses);
 	}
@@ -45,8 +45,8 @@ public class AggregatedData {
 		}
 
 		/**
-		 * This is the static factory method of the class AggregatedData.Builder. To
-		 * build an AggregatedData, possibly from only CoursePrefs, a set of Course is
+		 * This is the static factory method of the class AggregatedPrefs.Builder. To
+		 * build an AggregatedPrefs, possibly from only CoursePrefs, a set of Course is
 		 * necessary to serve as a reference.
 		 * 
 		 */
@@ -55,9 +55,9 @@ public class AggregatedData {
 			return new Builder(courses);
 		}
 
-		public AggregatedData build() {
+		public AggregatedPrefs build() {
 			mapToTeacherPrefs();
-			return new AggregatedData(tempTeacherPrefsSet, courses);
+			return new AggregatedPrefs(tempTeacherPrefsSet, courses);
 		}
 
 		/**
@@ -99,7 +99,7 @@ public class AggregatedData {
 		}
 
 		/**
-		 * This method allows to build an AggregatedData by adding a set of CoursePref.
+		 * This method allows to build an AggregatedPrefs by adding a set of CoursePref.
 		 * 
 		 * @param coursePrefs - the Set of coursePref to be added
 		 * 
@@ -126,7 +126,7 @@ public class AggregatedData {
 		/**
 		 * This method builds complete TeacherPrefs objects, using the CoursePrefs given
 		 * and stored in tempCoursePrefs, to complete tempTeacherPrefsSet the Set of
-		 * TeacherPrefs stored in the AggregatedData object.
+		 * TeacherPrefs stored in the AggregatedPrefs object.
 		 */
 		private void mapToTeacherPrefs() {
 			for (Map.Entry<Teacher, Set<CoursePref>> mapentry : tempCoursePrefs.entrySet()) {

--- a/src/main/java/io/github/oliviercailloux/teach_spreadsheets/base/AggregatedPrefs.java
+++ b/src/main/java/io/github/oliviercailloux/teach_spreadsheets/base/AggregatedPrefs.java
@@ -137,12 +137,12 @@ public class AggregatedPrefs {
 				 * The following line builds a set whose real type is mutable. courses attribute
 				 * remains intact.
 				 */
-				Set<Course> courses = new LinkedHashSet<>(this.courses);
+				Set<Course> coursesLeft = new LinkedHashSet<>(this.courses);
 				Set<Course> coursesInCoursePrefs = coursePrefs.stream().map(CoursePref::getCourse)
 						.collect(Collectors.toSet());
-				courses.removeAll(coursesInCoursePrefs);
+				coursesLeft.removeAll(coursesInCoursePrefs);
 
-				for (Course course : courses) {
+				for (Course course : coursesLeft) {
 					CoursePref coursePref = CoursePref.Builder.newInstance(course, teacher).build();
 					coursePrefs.add(coursePref);
 				}

--- a/src/main/java/io/github/oliviercailloux/teach_spreadsheets/read/MultipleOdsPrefReader.java
+++ b/src/main/java/io/github/oliviercailloux/teach_spreadsheets/read/MultipleOdsPrefReader.java
@@ -11,7 +11,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import io.github.oliviercailloux.teach_spreadsheets.base.AggregatedData;
+import io.github.oliviercailloux.teach_spreadsheets.base.AggregatedPrefs;
 import io.github.oliviercailloux.teach_spreadsheets.base.Course;
 import io.github.oliviercailloux.teach_spreadsheets.base.TeacherPrefs;
 
@@ -28,11 +28,11 @@ public class MultipleOdsPrefReader {
 	 * 
 	 * @param pathToFolder the path to the folder where all the Ods files are.This
 	 *                     path should not be null.
-	 * @return an AggregatedData containing all the TeacherPrefs from all the read
+	 * @return an AggregatedPrefs containing all the TeacherPrefs from all the read
 	 *         files.
 	 * @throws IOException, Exception
 	 */
-	public static AggregatedData readFilesFromFolder(Path pathToFolder) throws IOException, Exception {
+	public static AggregatedPrefs readFilesFromFolder(Path pathToFolder) throws IOException, Exception {
 		checkNotNull(pathToFolder);
 		Set<TeacherPrefs> teacherPrefsSet = new LinkedHashSet<>();
 		Set<Course> courses = new LinkedHashSet<>();
@@ -48,8 +48,8 @@ public class MultipleOdsPrefReader {
 				}
 			}
 		}
-		AggregatedData.Builder aggregatedDataBuilder = AggregatedData.Builder.newInstance(courses);
-		aggregatedDataBuilder.addTeacherPrefsSet(teacherPrefsSet);
-		return aggregatedDataBuilder.build();
+		AggregatedPrefs.Builder aggregatedPrefsBuilder = AggregatedPrefs.Builder.newInstance(courses);
+		aggregatedPrefsBuilder.addTeacherPrefsSet(teacherPrefsSet);
+		return aggregatedPrefsBuilder.build();
 	}
 }

--- a/src/test/java/io/github/oliviercailloux/teach_spreadsheets/base/AggregatedPrefsTests.java
+++ b/src/test/java/io/github/oliviercailloux/teach_spreadsheets/base/AggregatedPrefsTests.java
@@ -13,7 +13,7 @@ import org.junit.jupiter.api.Test;
 
 import com.google.common.collect.ImmutableSet;
 
-public class AggregatedDataTests {
+public class AggregatedPrefsTests {
 
 	private static Teacher teacher1 = Teacher.Builder.newInstance().setLastName("Dupond").setFirstName("Jack").build();
 	private static Teacher teacher2 = Teacher.Builder.newInstance().setLastName("Dupont").setFirstName("Jane").build();
@@ -45,63 +45,63 @@ public class AggregatedDataTests {
 
 	@Test
 	void testAddTeacherPrefsWithSameTeacher() {
-		AggregatedData.Builder aggregatedDataBuilder = AggregatedData.Builder.newInstance(courses1);
-		aggregatedDataBuilder.addTeacherPrefs(teacherPrefs1);
+		AggregatedPrefs.Builder aggregatedPrefsBuilder = AggregatedPrefs.Builder.newInstance(courses1);
+		aggregatedPrefsBuilder.addTeacherPrefs(teacherPrefs1);
 		Throwable exception = assertThrows(IllegalArgumentException.class, () -> {
-			aggregatedDataBuilder.addTeacherPrefs(teacherPrefs2);
+			aggregatedPrefsBuilder.addTeacherPrefs(teacherPrefs2);
 		});
 		assertEquals("You cannot add twice all the preferences of the teacher : " + teacher1, exception.getMessage());
 	}
 
 	@Test
 	void testAddTeacherPrefsWithDifferentCourses() {
-		AggregatedData.Builder aggregatedData = AggregatedData.Builder.newInstance(courses1);
-		aggregatedData.addTeacherPrefs(teacherPrefs1);
+		AggregatedPrefs.Builder aggregatedPrefs = AggregatedPrefs.Builder.newInstance(courses1);
+		aggregatedPrefs.addTeacherPrefs(teacherPrefs1);
 		Throwable exception = assertThrows(IllegalArgumentException.class, () -> {
-			aggregatedData.addTeacherPrefs(teacherPrefs3);
+			aggregatedPrefs.addTeacherPrefs(teacherPrefs3);
 		});
 		assertEquals("There must be the same courses in the teacherPrefs.", exception.getMessage());
 	}
 	
 	@Test
-	void testBuildAggregatedDatasWithCoursePrefs() {
-		AggregatedData.Builder aggregatedDataBuilder = AggregatedData.Builder.newInstance(courses2);
-		aggregatedDataBuilder.addCoursePrefs(Set.of(coursePref1, coursePref3, coursePref4));
-		AggregatedData aggregatedData = aggregatedDataBuilder.build();
+	void testBuildAggregatedPrefsWithCoursePrefs() {
+		AggregatedPrefs.Builder aggregatedPrefsBuilder = AggregatedPrefs.Builder.newInstance(courses2);
+		aggregatedPrefsBuilder.addCoursePrefs(Set.of(coursePref1, coursePref3, coursePref4));
+		AggregatedPrefs aggregatedPrefs = aggregatedPrefsBuilder.build();
 
-		assertTrue(aggregatedData.getTeacherPrefsSet().size() == 2);
+		assertTrue(aggregatedPrefs.getTeacherPrefsSet().size() == 2);
 
-		assertEquals(teacherPrefs5.getCoursePrefs(), aggregatedData.getTeacherPrefs(teacher1));
-		assertEquals(teacherPrefs6.getCoursePrefs(), aggregatedData.getTeacherPrefs(teacher2));
+		assertEquals(teacherPrefs5.getCoursePrefs(), aggregatedPrefs.getTeacherPrefs(teacher1));
+		assertEquals(teacherPrefs6.getCoursePrefs(), aggregatedPrefs.getTeacherPrefs(teacher2));
 	}
 
 	@Test
-	void testBuildAggregatedDataWithCoursePrefsAndTeacherPrefs() {
-		AggregatedData.Builder aggregatedDataBuilder = AggregatedData.Builder.newInstance(courses2);
-		aggregatedDataBuilder.addCoursePrefs(Set.of(coursePref1));
-		aggregatedDataBuilder.addTeacherPrefs(teacherPrefs6);
+	void testBuildAggregatedPrefsWithCoursePrefsAndTeacherPrefs() {
+		AggregatedPrefs.Builder aggregatedPrefsBuilder = AggregatedPrefs.Builder.newInstance(courses2);
+		aggregatedPrefsBuilder.addCoursePrefs(Set.of(coursePref1));
+		aggregatedPrefsBuilder.addTeacherPrefs(teacherPrefs6);
 
-		AggregatedData aggregatedData = aggregatedDataBuilder.build();
+		AggregatedPrefs aggregatedPrefs = aggregatedPrefsBuilder.build();
 
-		assertTrue(aggregatedData.getTeacherPrefsSet().size() == 2);
+		assertTrue(aggregatedPrefs.getTeacherPrefsSet().size() == 2);
 
-		assertEquals(teacherPrefs5.getCoursePrefs(), aggregatedData.getTeacherPrefs(teacher1));
-		assertEquals(teacherPrefs6.getCoursePrefs(), aggregatedData.getTeacherPrefs(teacher2));
+		assertEquals(teacherPrefs5.getCoursePrefs(), aggregatedPrefs.getTeacherPrefs(teacher1));
+		assertEquals(teacherPrefs6.getCoursePrefs(), aggregatedPrefs.getTeacherPrefs(teacher2));
 	}
 
 	/**
 	 * The aim of this method is to test that when we will concretely and
-	 * realistically use the class AggregatedData, it works properly.
+	 * realistically use the class AggregatedPrefs, it works properly.
 	 */
 	@Test
 	void testAddTeacherPrefsConcretely() throws Exception {
-		URL resourceUrl1 = AggregatedData.class.getResource("Saisie_des_voeux_format simple1.ods");
+		URL resourceUrl1 = AggregatedPrefs.class.getResource("Saisie_des_voeux_format simple1.ods");
 		TeacherPrefs cd1;
 		try (InputStream stream = resourceUrl1.openStream()) {
 			cd1 = TeacherPrefs.fromOds(stream);
 		}
 
-		URL resourceUrl2 = AggregatedData.class.getResource("Saisie_des_voeux_format simple2.ods");
+		URL resourceUrl2 = AggregatedPrefs.class.getResource("Saisie_des_voeux_format simple2.ods");
 		TeacherPrefs cd2;
 		try (InputStream stream = resourceUrl2.openStream()) {
 			cd2 = TeacherPrefs.fromOds(stream);
@@ -109,33 +109,33 @@ public class AggregatedDataTests {
 		
 		Set<Course> courses = cd1.getCourses();
 
-		AggregatedData.Builder aggregatedDataBuilder = AggregatedData.Builder.newInstance(courses);
-		aggregatedDataBuilder.addTeacherPrefs(cd1);
+		AggregatedPrefs.Builder aggregatedPrefsBuilder = AggregatedPrefs.Builder.newInstance(courses);
+		aggregatedPrefsBuilder.addTeacherPrefs(cd1);
 		assertDoesNotThrow(() -> {
-			aggregatedDataBuilder.addTeacherPrefs(cd2);
-			aggregatedDataBuilder.build();
+			aggregatedPrefsBuilder.addTeacherPrefs(cd2);
+			aggregatedPrefsBuilder.build();
 		});
 		
 	}
 
 	@Test
 	void testGetTeacherPrefs() {
-		AggregatedData.Builder aggregatedDataBuilder = AggregatedData.Builder.newInstance(courses1);
-		aggregatedDataBuilder.addTeacherPrefs(teacherPrefs1);
-		aggregatedDataBuilder.addTeacherPrefs(teacherPrefs4);
-		AggregatedData aggregatedData = aggregatedDataBuilder.build();
+		AggregatedPrefs.Builder aggregatedPrefsBuilder = AggregatedPrefs.Builder.newInstance(courses1);
+		aggregatedPrefsBuilder.addTeacherPrefs(teacherPrefs1);
+		aggregatedPrefsBuilder.addTeacherPrefs(teacherPrefs4);
+		AggregatedPrefs aggregatedPrefs = aggregatedPrefsBuilder.build();
 
-		assertEquals(ImmutableSet.of(coursePref1), aggregatedData.getTeacherPrefs(teacher1));
+		assertEquals(ImmutableSet.of(coursePref1), aggregatedPrefs.getTeacherPrefs(teacher1));
 	}
 
 	@Test
 	void testGetCoursePrefs() {
-		AggregatedData.Builder aggregatedDataBuilder = AggregatedData.Builder.newInstance(courses1);
-		aggregatedDataBuilder.addTeacherPrefs(teacherPrefs1);
-		aggregatedDataBuilder.addTeacherPrefs(teacherPrefs4);
-		AggregatedData aggregatedData = aggregatedDataBuilder.build();
+		AggregatedPrefs.Builder aggregatedPrefsBuilder = AggregatedPrefs.Builder.newInstance(courses1);
+		aggregatedPrefsBuilder.addTeacherPrefs(teacherPrefs1);
+		aggregatedPrefsBuilder.addTeacherPrefs(teacherPrefs4);
+		AggregatedPrefs aggregatedPrefs = aggregatedPrefsBuilder.build();
 
-		assertEquals(ImmutableSet.of(coursePref1, coursePref4), aggregatedData.getCoursePrefs(course1));
+		assertEquals(ImmutableSet.of(coursePref1, coursePref4), aggregatedPrefs.getCoursePrefs(course1));
 	}
 
 }


### PR DESCRIPTION
La tâche associée à cette PR consiste en un simple renommage de AggregatedData en AggregatedPrefs afin de coller au nommage en UML et d'éclaircir le rôle de cette classe.
Egalement, il a été effectué un renommage, dans la classe, d'une variable pour ne plus avoir de warning Eclipse.